### PR TITLE
Fix hardcoded backend URL in serverConfig.js

### DIFF
--- a/client/src/services/serverConfig.js
+++ b/client/src/services/serverConfig.js
@@ -1,15 +1,3 @@
-let apiUrl;
-
-console.log('mode', import.meta.env.MODE);
-
-if (import.meta.env.MODE === 'production') {
-  // When running in production mode (vite preview)
-  apiUrl = 'https://nodejs-production-c255.up.railway.app';
-} else {
-  // When running in dev mode (npm run dev)
-  apiUrl = 'http://localhost:3000';
-}
-
-// console.log('apiUrl at serverConfig:', apiUrl);
+const apiUrl = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
 export default apiUrl;


### PR DESCRIPTION
Old serverConfig.js had the Railway URL hardcoded for production mode. Both .js and .ts versions exist; Vite loads the .js file as an exact match, so the .ts version using VITE_API_URL was never reached.

https://claude.ai/code/session_018e7oNPu4nzjRQ8KEvdR8ng