### PR TITLE
Fix cross-origin cookie rejection by switching to SameSite=None

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -10,8 +10,8 @@ dotenv.config();
 
 const COOKIE_OPTIONS = {
   httpOnly: true,
-  secure: process.env.NODE_ENV === 'production',
-  sameSite: 'strict' as const,
+  secure: true,
+  sameSite: 'none' as const,
   maxAge: 3600000, // 1 hour
 };
 
@@ -93,7 +93,7 @@ export const login = async (req: Request, res: Response): Promise<void> => {
 };
 
 export const logout = (_req: Request, res: Response): void => {
-  res.clearCookie('token', { httpOnly: true, secure: process.env.NODE_ENV === 'production', sameSite: 'strict' });
+  res.clearCookie('token', { httpOnly: true, secure: true, sameSite: 'none' });
   res.json({ msg: 'Logged out' });
 };
 


### PR DESCRIPTION
Frontend (slamtheline.com) and backend (railway.app) are on different domains. SameSite=Strict causes the browser to block the cookie on all cross-origin requests, so /auth/verify never receives it and the user appears logged out after login. SameSite=None with Secure=true is the correct setting for cross-origin httpOnly cookies.

https://claude.ai/code/session_018e7oNPu4nzjRQ8KEvdR8ng