### PR TITLE
Reduce Pickgrid from ~200 requests to 4 with bulk endpoints

### DIFF
--- a/backend/controllers/gameController.ts
+++ b/backend/controllers/gameController.ts
@@ -2,6 +2,28 @@ import { Request, Response } from 'express';
 import pool from '../config/db.js';
 import logger from '../utils/logger.js';
 
+export const getGamesBySeason = async (req: Request, res: Response): Promise<void> => {
+  const { year } = req.params;
+  const query = `
+    SELECT g.*,
+           ht.name AS home_team_name,
+           ht.abbr AS home_team_abbr,
+           at.name AS away_team_name,
+           at.abbr AS away_team_abbr
+    FROM games g
+    JOIN teams ht ON g.home_team_id = ht.id
+    JOIN teams at ON g.away_team_id = at.id
+    WHERE g.nfl_year = ?
+  `;
+  try {
+    const [rows] = await pool.query(query, [year]);
+    res.json(rows);
+  } catch (err: any) {
+    logger.error('getGamesBySeason error', { error: err.message });
+    res.status(500).json({ error: 'Failed to fetch games' });
+  }
+};
+
 export const getGamesByWeek = async (req: Request, res: Response): Promise<void> => {
   const { week } = req.params;
   const query = `

--- a/backend/controllers/userSelectionsController.ts
+++ b/backend/controllers/userSelectionsController.ts
@@ -2,6 +2,20 @@ import { Request, Response } from 'express';
 import pool from '../config/db.js';
 import logger from '../utils/logger.js';
 
+export const getAllLeagueSelections = async (req: Request, res: Response): Promise<void> => {
+  const { leagueId } = req.params;
+  try {
+    const [selections] = await pool.query(
+      'SELECT * FROM users_select_games WHERE league_id = ?',
+      [leagueId]
+    );
+    res.status(200).json(selections);
+  } catch (err: any) {
+    logger.error('getAllLeagueSelections error', { error: err.message });
+    res.status(500).json({ msg: 'Server error' });
+  }
+};
+
 export const userSelections = async (req: Request, res: Response): Promise<void> => {
   const { leagueId, userId, week } = req.params;
 

--- a/backend/routes/gameRoute.ts
+++ b/backend/routes/gameRoute.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
-import { getGamesByWeek } from '../controllers/gameController.js';
+import { getGamesByWeek, getGamesBySeason } from '../controllers/gameController.js';
 import auth from '../middleware/authMiddleware.js';
 
 const router = Router();
 
+router.get('/season/:year', auth, getGamesBySeason);
 router.get('/:week', auth, getGamesByWeek);
 
 export default router;

--- a/backend/routes/userSelectionsRoute.ts
+++ b/backend/routes/userSelectionsRoute.ts
@@ -1,9 +1,10 @@
 import { Router } from 'express';
-import { userSelections } from '../controllers/userSelectionsController.js';
+import { userSelections, getAllLeagueSelections } from '../controllers/userSelectionsController.js';
 import auth from '../middleware/authMiddleware.js';
 
 const router = Router();
 
+router.get('/:leagueId', auth, getAllLeagueSelections);
 router.get('/:leagueId/:userId/:week', auth, userSelections);
 
 export default router;

--- a/client/src/pages/Pickgrid.tsx
+++ b/client/src/pages/Pickgrid.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect, useContext } from 'react';
 import { useParams } from 'react-router-dom';
 import axios from 'axios';
-import { AuthContext } from '../context/AuthContext.jsx';
-import Topbar from '../components/Topbar.jsx';
-import apiUrl from '../services/serverConfig.js';
+import { AuthContext } from '../context/AuthContext.tsx';
+import Topbar from '../components/Topbar.tsx';
+import apiUrl from '../services/serverConfig.ts';
 
 const Pickgrid = () => {
   const { leagueId } = useParams<{ leagueId: string }>();
@@ -23,37 +23,26 @@ const Pickgrid = () => {
         ]);
         const league = leagueRes.data.league[0];
         setLeagueInfo(league);
+        setUsers(usersRes.data);
 
-        const gameResponses = await Promise.all(
-          Array.from({ length: 18 }, (_, i) => axios.get(`${apiUrl}/games/${i + 1}`))
-        );
-        const allGames = gameResponses.reduce<Record<number, Record<number, any>>>((acc, res, i) => {
-          const week = i + 1;
-          acc[week] = res.data
-            .filter((g: any) => g.nfl_year === league.year)
-            .reduce((ga: any, g: any) => { ga[g.id] = g; return ga; }, {});
-          return acc;
-        }, {});
+        const [gamesRes, selectionsRes] = await Promise.all([
+          axios.get(`${apiUrl}/games/season/${league.year}`),
+          axios.get(`${apiUrl}/userselections/${leagueId}`),
+        ]);
+
+        const allGames: Record<number, Record<number, any>> = {};
+        for (const g of gamesRes.data) {
+          if (!allGames[g.week]) allGames[g.week] = {};
+          allGames[g.week][g.id] = g;
+        }
         setGames(allGames);
 
-        const fetchedUsers = usersRes.data;
-        setUsers(fetchedUsers);
-
-        const selectionResults = await Promise.all(
-          fetchedUsers.flatMap((u: any) =>
-            Array.from({ length: 18 }, (_, i) =>
-              axios.get(`${apiUrl}/userselections/${leagueId}/${u.user_id}/${i + 1}`)
-                .then((res) => ({ userId: u.user_id, week: i + 1, selections: res.data.league || [] }))
-                .catch(() => ({ userId: u.user_id, week: i + 1, selections: [] }))
-            )
-          )
-        );
-
-        const organized = selectionResults.reduce<Record<number, Record<number, any[]>>>((acc, { userId, week, selections }) => {
-          if (!acc[userId]) acc[userId] = {};
-          acc[userId][week] = selections;
-          return acc;
-        }, {});
+        const organized: Record<number, Record<number, any[]>> = {};
+        for (const s of selectionsRes.data) {
+          if (!organized[s.user_id]) organized[s.user_id] = {};
+          if (!organized[s.user_id][s.week]) organized[s.user_id][s.week] = [];
+          organized[s.user_id][s.week].push(s);
+        }
         setUserSelections(organized);
       } catch (err) {
         console.error('Error fetching pickgrid data:', err);


### PR DESCRIPTION
Added GET /games/season/:year and GET /userselections/:leagueId to return all season games and all league selections in single queries. Pickgrid now fetches league+users in parallel, then games+selections in parallel, instead of making 18 game requests and N*18 selection requests.

https://claude.ai/code/session_018e7oNPu4nzjRQ8KEvdR8ng