### PR TITLE
Restore SameSite=Strict now that backend is on api.slamtheline.com

### DIFF
--- a/backend/controllers/authController.ts
+++ b/backend/controllers/authController.ts
@@ -11,7 +11,7 @@ dotenv.config();
 const COOKIE_OPTIONS = {
   httpOnly: true,
   secure: true,
-  sameSite: 'none' as const,
+  sameSite: 'strict' as const,
   maxAge: 3600000, // 1 hour
 };
 
@@ -93,7 +93,7 @@ export const login = async (req: Request, res: Response): Promise<void> => {
 };
 
 export const logout = (_req: Request, res: Response): void => {
-  res.clearCookie('token', { httpOnly: true, secure: true, sameSite: 'none' });
+  res.clearCookie('token', { httpOnly: true, secure: true, sameSite: 'strict' });
   res.json({ msg: 'Logged out' });
 };
 


### PR DESCRIPTION
Frontend and backend now share the slamtheline.com registrable domain, making cookies same-site. SameSite=None is no longer needed and the cross-site cookie deprecation warning is resolved.

https://claude.ai/code/session_018e7oNPu4nzjRQ8KEvdR8ng