### PR TITLE
Desktop layout, compact picksheet cards, unified tab bar

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -27,21 +27,28 @@ const Commissioner = lazy(() => import('./pages/Commissioner.tsx'));
 
 const AUTH_PATHS = ['/login', '/register', '/updatepassword'];
 
+// Center content on desktop while staying full-width on mobile
+const PageCenter = ({ children, fullScreen }: { children: React.ReactNode; fullScreen?: boolean }) => (
+  <div style={{ background: '#0c1628', minHeight: fullScreen ? '100vh' : 'calc(100vh - 56px)', display: 'flex', justifyContent: 'center' }}>
+    <div style={{ width: '100%', maxWidth: 720 }}>
+      {children}
+    </div>
+  </div>
+);
+
 const Layout = ({ children }: { children: React.ReactNode }) => {
   const location = useLocation();
   const isAuthPage = AUTH_PATHS.includes(location.pathname);
   const isLeaguePage = location.pathname.startsWith('/league/');
 
-  // Auth pages and league pages manage their own full-screen layout
-  if (isAuthPage || isLeaguePage) return <>{children}</>;
+  if (isAuthPage || isLeaguePage) {
+    return <PageCenter fullScreen>{children}</PageCenter>;
+  }
 
-  // Home, JoinLeague, CreateLeague, UserProfile get the Navbar
   return (
     <>
       <Navbar />
-      <div style={{ background: '#0c1628', minHeight: 'calc(100vh - 56px)' }}>
-        {children}
-      </div>
+      <PageCenter>{children}</PageCenter>
     </>
   );
 };

--- a/client/src/components/LeagueTabBar.tsx
+++ b/client/src/components/LeagueTabBar.tsx
@@ -29,28 +29,29 @@ const LeagueTabBar = ({ leagueId }: { leagueId: string | undefined }) => {
 
   return (
     <div style={{
-      position: 'fixed', bottom: 0, left: 0, right: 0, height: 64,
-      background: C.bg, borderTop: `1px solid ${C.bor}`,
-      display: 'flex', alignItems: 'stretch', zIndex: 100,
+      position: 'fixed', bottom: 0, left: 0, right: 0,
+      background: C.bg, borderTop: `1px solid ${C.bor}`, zIndex: 100,
     }}>
-      {tabs.map((tab) => {
-        const isActive = location.pathname === tab.path;
-        return (
-          <Link
-            key={tab.path}
-            to={tab.path}
-            style={{
-              flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
-              textDecoration: 'none', fontFamily: FF, fontSize: 13, fontWeight: 700,
-              letterSpacing: 0.5, textTransform: 'uppercase',
-              color: isActive ? C.amb : C.mut,
-              borderTop: isActive ? `2px solid ${C.amb}` : '2px solid transparent',
-            }}
-          >
-            {tab.label}
-          </Link>
-        );
-      })}
+      <div style={{ maxWidth: 720, margin: '0 auto', height: 64, display: 'flex', alignItems: 'stretch' }}>
+        {tabs.map((tab) => {
+          const isActive = location.pathname === tab.path;
+          return (
+            <Link
+              key={tab.path}
+              to={tab.path}
+              style={{
+                flex: 1, display: 'flex', alignItems: 'center', justifyContent: 'center',
+                textDecoration: 'none', fontFamily: FF, fontSize: 13, fontWeight: 700,
+                letterSpacing: 0.5, textTransform: 'uppercase',
+                color: isActive ? C.amb : C.mut,
+                borderTop: isActive ? `2px solid ${C.amb}` : '2px solid transparent',
+              }}
+            >
+              {tab.label}
+            </Link>
+          );
+        })}
+      </div>
     </div>
   );
 };

--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -10,31 +10,32 @@ const Navbar = () => {
   const { logout } = useContext(AuthContext);
 
   return (
-    <div style={{
-      background: '#152540', borderBottom: '1px solid #1e3354',
-      height: 56, display: 'flex', alignItems: 'center',
-      padding: '0 20px', position: 'sticky', top: 0, zIndex: 200,
-      justifyContent: 'space-between',
-    }}>
-      <Link to="/" style={{ display: 'flex', alignItems: 'center', gap: 10, textDecoration: 'none' }}>
-        <img src={Logo} alt="STL" style={{ width: 36, height: 36, objectFit: 'contain' }} />
-        <span style={{ fontFamily: FF, fontSize: 18, fontWeight: 900, color: '#fff', textTransform: 'uppercase', letterSpacing: 0.5 }}>
-          Slam the Line
-        </span>
-      </Link>
-      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
-        <LeagueDropdown />
-        <button
-          onClick={logout}
-          style={{
-            background: 'none', border: '1px solid #1e3354', color: '#475569',
-            fontFamily: FF, fontSize: 13, fontWeight: 700, letterSpacing: 1,
-            padding: '6px 14px', borderRadius: 8, cursor: 'pointer',
-            textTransform: 'uppercase',
-          }}
-        >
-          Logout
-        </button>
+    <div style={{ background: '#152540', borderBottom: '1px solid #1e3354', position: 'sticky', top: 0, zIndex: 200 }}>
+      <div style={{
+        maxWidth: 720, margin: '0 auto', height: 56,
+        display: 'flex', alignItems: 'center',
+        padding: '0 20px', justifyContent: 'space-between',
+      }}>
+        <Link to="/" style={{ display: 'flex', alignItems: 'center', gap: 10, textDecoration: 'none' }}>
+          <img src={Logo} alt="STL" style={{ width: 36, height: 36, objectFit: 'contain' }} />
+          <span style={{ fontFamily: FF, fontSize: 18, fontWeight: 900, color: '#fff', textTransform: 'uppercase', letterSpacing: 0.5 }}>
+            Slam the Line
+          </span>
+        </Link>
+        <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+          <LeagueDropdown />
+          <button
+            onClick={logout}
+            style={{
+              background: 'none', border: '1px solid #1e3354', color: '#475569',
+              fontFamily: FF, fontSize: 13, fontWeight: 700, letterSpacing: 1,
+              padding: '6px 14px', borderRadius: 8, cursor: 'pointer',
+              textTransform: 'uppercase',
+            }}
+          >
+            Logout
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/client/src/pages/Picksheet.tsx
+++ b/client/src/pages/Picksheet.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect, useContext } from 'react';
-import { useParams, useNavigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import axios from 'axios';
 import { AuthContext } from '../context/AuthContext.tsx';
 import { WeekContext } from '../context/WeekContext.tsx';
+import LeagueTabBar from '../components/LeagueTabBar.tsx';
 import apiUrl from '../services/serverConfig.ts';
 
 const C = {
@@ -13,42 +14,11 @@ const C = {
 
 const FF = "'Barlow Condensed', sans-serif";
 
-const ICO = {
-  picks: (c: string) => (
-    <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
-      <rect x="5" y="2" width="14" height="20" rx="2.5" stroke={c} strokeWidth="1.8"/>
-      <line x1="9" y1="8" x2="15" y2="8" stroke={c} strokeWidth="1.8" strokeLinecap="round"/>
-      <line x1="9" y1="12" x2="15" y2="12" stroke={c} strokeWidth="1.8" strokeLinecap="round"/>
-      <line x1="9" y1="16" x2="12" y2="16" stroke={c} strokeWidth="1.8" strokeLinecap="round"/>
-    </svg>
-  ),
-  trophy: (c: string) => (
-    <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
-      <path d="M6 3H4a1 1 0 00-1 1v2c0 2 1.5 4 3.5 4.5M18 3h2a1 1 0 011 1v2c0 2-1.5 4-3.5 4.5M16 3H8v7a4 4 0 008 0V3zM9 20h6M12 16v4" stroke={c} strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/>
-    </svg>
-  ),
-  grid: (c: string) => (
-    <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
-      <rect x="3" y="3" width="7" height="7" rx="1.5" stroke={c} strokeWidth="1.8"/>
-      <rect x="14" y="3" width="7" height="7" rx="1.5" stroke={c} strokeWidth="1.8"/>
-      <rect x="3" y="14" width="7" height="7" rx="1.5" stroke={c} strokeWidth="1.8"/>
-      <rect x="14" y="14" width="7" height="7" rx="1.5" stroke={c} strokeWidth="1.8"/>
-    </svg>
-  ),
-  league: (c: string) => (
-    <svg width="22" height="22" viewBox="0 0 24 24" fill="none">
-      <circle cx="12" cy="12" r="9" stroke={c} strokeWidth="1.8"/>
-      <path d="M12 3c2.5 4 2.5 14 0 18M12 3c-2.5 4-2.5 14 0 18M3 12h18" stroke={c} strokeWidth="1.5" strokeLinecap="round"/>
-    </svg>
-  ),
-};
-
 const Picksheet = () => {
   const { leagueId } = useParams<{ leagueId: string }>();
   const { week } = useContext(WeekContext) as { week: number };
   const { user } = useContext(AuthContext);
   const userId = user?.userId;
-  const navigate = useNavigate();
 
   const [games, setGames] = useState<any[]>([]);
   const [leagueInfo, setLeagueInfo] = useState<any>({});
@@ -175,52 +145,45 @@ const Picksheet = () => {
     </div>
   );
 
-  const TABS = [
-    { ico: ICO.picks,  label: 'Picks',     path: `/league/${leagueId}/picksheet`,  active: true },
-    { ico: ICO.trophy, label: 'Standings', path: `/league/${leagueId}/standings`,  active: false },
-    { ico: ICO.grid,   label: 'Grid',      path: `/league/${leagueId}/pickgrid`,   active: false },
-    { ico: ICO.league, label: 'League',    path: `/league/${leagueId}`,            active: false },
-  ];
-
   return (
     <div style={{ minHeight: '100vh', background: C.bg, fontFamily: FF, display: 'flex', flexDirection: 'column' }}>
 
-      {/* ── Branded header ── */}
+      {/* Header */}
       <div style={{
         background: 'linear-gradient(160deg, #1a3a7a 0%, #0c1628 100%)',
-        padding: '16px 16px 14px', position: 'relative', overflow: 'hidden',
+        padding: '14px 16px 12px', position: 'relative', overflow: 'hidden',
       }}>
         <div style={{ position: 'absolute', top: -50, right: -50, width: 150, height: 150, borderRadius: 99, background: 'rgba(99,102,241,0.12)', pointerEvents: 'none' }} />
         <div style={{ position: 'absolute', bottom: -30, left: -20, width: 80, height: 80, borderRadius: 99, background: 'rgba(245,158,11,0.08)', pointerEvents: 'none' }} />
         <div style={{ fontSize: 11, fontWeight: 700, letterSpacing: 3, color: 'rgba(255,255,255,0.35)', textTransform: 'uppercase', marginBottom: 2 }}>
           {leagueInfo.name}
         </div>
-        <div style={{ fontSize: 30, fontWeight: 900, color: '#fff', letterSpacing: -0.5, lineHeight: 1, textTransform: 'uppercase' }}>
+        <div style={{ fontSize: 28, fontWeight: 900, color: '#fff', letterSpacing: -0.5, lineHeight: 1, textTransform: 'uppercase' }}>
           Week {week} Picks
         </div>
-        <div style={{ display: 'flex', gap: 8, marginTop: 10, flexWrap: 'wrap' }}>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '5px 12px', background: 'rgba(255,255,255,0.07)', borderRadius: 99, border: '1px solid rgba(255,255,255,0.1)' }}>
-            <div style={{ width: 7, height: 7, borderRadius: 99, background: totalUsed === totalPts ? C.grn : totalUsed > totalPts ? C.red : C.amb }} />
-            <span style={{ fontSize: 12, fontWeight: 700, color: 'rgba(255,255,255,0.85)' }}>{totalUsed} / {totalPts} pts</span>
+        <div style={{ display: 'flex', gap: 6, marginTop: 8, flexWrap: 'wrap' }}>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '4px 10px', background: 'rgba(255,255,255,0.07)', borderRadius: 99, border: '1px solid rgba(255,255,255,0.1)' }}>
+            <div style={{ width: 6, height: 6, borderRadius: 99, background: totalUsed === totalPts ? C.grn : totalUsed > totalPts ? C.red : C.amb }} />
+            <span style={{ fontSize: 11, fontWeight: 700, color: 'rgba(255,255,255,0.85)' }}>{totalUsed} / {totalPts} pts</span>
           </div>
-          <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '5px 12px', background: 'rgba(255,255,255,0.07)', borderRadius: 99, border: '1px solid rgba(255,255,255,0.1)' }}>
-            <span style={{ fontSize: 12, fontWeight: 700, color: pickCount >= minPicks ? C.grn : C.amb }}>{pickCount} picks · need {minPicks}–{maxPicks}</span>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '4px 10px', background: 'rgba(255,255,255,0.07)', borderRadius: 99, border: '1px solid rgba(255,255,255,0.1)' }}>
+            <span style={{ fontSize: 11, fontWeight: 700, color: pickCount >= minPicks ? C.grn : C.amb }}>{pickCount} picks · need {minPicks}–{maxPicks}</span>
           </div>
           {hasExistingSelections && (
-            <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '5px 12px', background: `${C.grn}22`, borderRadius: 99, border: `1px solid ${C.grn}44` }}>
-              <span style={{ fontSize: 12, fontWeight: 700, color: C.grn }}>✓ Picks submitted</span>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 5, padding: '4px 10px', background: `${C.grn}22`, borderRadius: 99, border: `1px solid ${C.grn}44` }}>
+              <span style={{ fontSize: 11, fontWeight: 700, color: C.grn }}>✓ Submitted</span>
             </div>
           )}
         </div>
       </div>
 
-      {/* progress bar */}
+      {/* Progress bar */}
       <div style={{ height: 3, background: C.bor }}>
         <div style={{ height: '100%', width: `${Math.min(100, (totalUsed / totalPts) * 100)}%`, background: totalUsed > totalPts ? C.red : C.ind, transition: 'width 0.2s' }} />
       </div>
 
-      {/* ── Games list ── */}
-      <div style={{ flex: 1, overflowY: 'auto', padding: '10px 16px 0', display: 'flex', flexDirection: 'column', gap: 8 }}>
+      {/* Games list */}
+      <div style={{ flex: 1, overflowY: 'auto', padding: '8px 12px 0', display: 'flex', flexDirection: 'column', gap: 6 }}>
         {games.length === 0 && (
           <p style={{ color: C.mut, fontSize: 16, textAlign: 'center', marginTop: 32 }}>No games available for this week.</p>
         )}
@@ -230,8 +193,8 @@ const Picksheet = () => {
           const p = weeklyPoints[game.id] || 5;
 
           const teams = [
-            { id: game.away_team_id, abbr: game.away_team_abbr, name: game.away_team_name, curr: game.away_curr_spread, open: game.away_open_spread },
-            { id: game.home_team_id, abbr: game.home_team_abbr, name: game.home_team_name, curr: game.home_curr_spread, open: game.home_open_spread },
+            { id: game.away_team_id, abbr: game.away_team_abbr, name: game.away_team_name, spread: game.away_curr_spread },
+            { id: game.home_team_id, abbr: game.home_team_abbr, name: game.home_team_name, spread: game.home_curr_spread },
           ];
 
           return (
@@ -239,38 +202,37 @@ const Picksheet = () => {
               background: C.card,
               border: isSel ? `1px solid ${C.amb}66` : `1px solid ${C.bor}`,
               borderLeft: isSel ? `3px solid ${C.amb}` : undefined,
-              borderRadius: 14, overflow: 'hidden',
-              opacity: locked ? 0.5 : 1,
+              borderRadius: 12, overflow: 'hidden',
+              opacity: locked ? 0.55 : 1,
             }}>
-              {/* date / time row */}
-              <div style={{ padding: '6px 12px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: C.d2 }}>
-                <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: 1.5, color: C.mut }}>{fmtDate(game.game_start_time)}</span>
-                <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: 1, color: locked ? C.red : C.mut }}>{locked ? 'LOCKED' : fmtTime(game.game_start_time)}</span>
+              {/* Date / time row */}
+              <div style={{ padding: '4px 10px', display: 'flex', justifyContent: 'space-between', alignItems: 'center', background: C.d2 }}>
+                <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: 1.5, color: C.mut }}>{fmtDate(game.game_start_time)}</span>
+                <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: 1, color: locked ? C.red : C.mut }}>{locked ? 'LOCKED' : fmtTime(game.game_start_time)}</span>
               </div>
 
-              {/* team buttons */}
-              <div style={{ padding: '8px 10px', display: 'flex', gap: 8 }}>
+              {/* Team buttons */}
+              <div style={{ padding: '6px 8px', display: 'flex', gap: 6 }}>
                 {teams.map((team) => {
                   const on = selectedTeam[game.id] === team.id;
                   return (
                     <div key={team.id}
                       onClick={() => handleSelectTeam(game.id, team.id)}
                       style={{
-                        flex: 1, padding: '10px 12px', borderRadius: 10,
+                        flex: 1, padding: '7px 10px', borderRadius: 8,
                         cursor: locked ? 'default' : 'pointer',
                         background: on ? `${C.amb}1a` : C.d2,
                         border: `2px solid ${on ? C.amb : 'transparent'}`,
                         display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-                        userSelect: 'none', gap: 8, minWidth: 0,
+                        userSelect: 'none', gap: 6, minWidth: 0,
                       }}>
-                      <div style={{ display: 'flex', flexDirection: 'column', gap: 1, minWidth: 0 }}>
-                        <span style={{ fontSize: 26, fontWeight: 900, color: on ? C.amb : C.txt, lineHeight: 1, letterSpacing: -0.5 }}>{team.abbr}</span>
-                        <span style={{ fontSize: 14, fontWeight: 700, color: on ? C.amb : C.txt }}>{fmt(team.curr)}</span>
-                        <span style={{ fontSize: 11, color: C.mut }}>Open: {fmt(team.open)}</span>
+                      <div style={{ display: 'flex', alignItems: 'baseline', gap: 7, minWidth: 0 }}>
+                        <span style={{ fontSize: 22, fontWeight: 900, color: on ? C.amb : C.txt, lineHeight: 1, letterSpacing: -0.5 }}>{team.abbr}</span>
+                        <span style={{ fontSize: 13, fontWeight: 700, color: on ? C.amb : C.mut }}>{fmt(team.spread)}</span>
                       </div>
                       {on && (
-                        <div style={{ flexShrink: 0, width: 22, height: 22, borderRadius: 99, background: C.amb, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                          <svg width="11" height="9" viewBox="0 0 11 9" fill="none"><path d="M1 4.5l3 3L10 1" stroke="#000" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                        <div style={{ flexShrink: 0, width: 18, height: 18, borderRadius: 99, background: C.amb, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                          <svg width="9" height="7" viewBox="0 0 11 9" fill="none"><path d="M1 4.5l3 3L10 1" stroke="#000" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"/></svg>
                         </div>
                       )}
                     </div>
@@ -278,22 +240,22 @@ const Picksheet = () => {
                 })}
               </div>
 
-              {/* points stepper — always visible */}
-              <div style={{ padding: '8px 14px 12px', display: 'flex', alignItems: 'center', borderTop: `1px solid ${C.bor}`, gap: 12 }}>
+              {/* Points stepper */}
+              <div style={{ padding: '6px 10px 8px', display: 'flex', alignItems: 'center', borderTop: `1px solid ${C.bor}`, gap: 10 }}>
                 <div style={{ flex: 1, minWidth: 0 }}>
                   {isSel
-                    ? <span style={{ fontSize: 12, fontWeight: 700, letterSpacing: 1.5, color: C.amb, textTransform: 'uppercase' }}>
+                    ? <span style={{ fontSize: 11, fontWeight: 700, letterSpacing: 1.5, color: C.amb, textTransform: 'uppercase' }}>
                         Points for <strong>{teams.find(t => t.id === isSel)?.abbr}</strong>
                       </span>
-                    : <span style={{ fontSize: 12, fontWeight: 600, letterSpacing: 1, color: C.mut, textTransform: 'uppercase' }}>← Tap a team, then set points</span>
+                    : <span style={{ fontSize: 11, fontWeight: 600, letterSpacing: 0.8, color: C.mut, textTransform: 'uppercase' }}>Select a team</span>
                   }
                 </div>
-                <div style={{ display: 'flex', alignItems: 'center', background: C.d2, borderRadius: 10, overflow: 'hidden', border: `1px solid ${C.bor}`, opacity: isSel && !locked ? 1 : 0.35 }}>
+                <div style={{ display: 'flex', alignItems: 'center', background: C.d2, borderRadius: 8, overflow: 'hidden', border: `1px solid ${C.bor}`, opacity: isSel && !locked ? 1 : 0.3 }}>
                   <button onClick={(e) => { e.stopPropagation(); adj(game.id, -1); }}
-                    style={{ width: 42, height: 40, background: 'transparent', border: 'none', borderRight: `1px solid ${C.bor}`, color: C.amb, fontSize: 24, fontWeight: 800, cursor: isSel ? 'pointer' : 'default', lineHeight: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: FF }}>−</button>
-                  <span style={{ width: 48, textAlign: 'center', fontSize: 24, fontWeight: 900, color: C.amb, lineHeight: 1 }}>{isSel ? p : '—'}</span>
+                    style={{ width: 36, height: 34, background: 'transparent', border: 'none', borderRight: `1px solid ${C.bor}`, color: C.amb, fontSize: 20, fontWeight: 800, cursor: isSel ? 'pointer' : 'default', lineHeight: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: FF }}>−</button>
+                  <span style={{ width: 40, textAlign: 'center', fontSize: 20, fontWeight: 900, color: C.amb, lineHeight: 1 }}>{isSel ? p : '—'}</span>
                   <button onClick={(e) => { e.stopPropagation(); adj(game.id, 1); }}
-                    style={{ width: 42, height: 40, background: 'transparent', border: 'none', borderLeft: `1px solid ${C.bor}`, color: C.amb, fontSize: 24, fontWeight: 800, cursor: isSel ? 'pointer' : 'default', lineHeight: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: FF }}>+</button>
+                    style={{ width: 36, height: 34, background: 'transparent', border: 'none', borderLeft: `1px solid ${C.bor}`, color: C.amb, fontSize: 20, fontWeight: 800, cursor: isSel ? 'pointer' : 'default', lineHeight: 1, display: 'flex', alignItems: 'center', justifyContent: 'center', fontFamily: FF }}>+</button>
                 </div>
               </div>
             </div>
@@ -302,36 +264,26 @@ const Picksheet = () => {
         <div style={{ height: 4 }} />
       </div>
 
-      {/* ── Footer ── */}
-      <div style={{ background: C.card, borderTop: `1px solid ${C.bor}` }}>
-        <div style={{ padding: '10px 16px 6px' }}>
-          <button onClick={handleSubmit} disabled={isSubmitting}
-            style={{
-              width: '100%', padding: '15px', borderRadius: 12,
-              background: isReady ? C.amb : '#162035',
-              border: `1px solid ${isReady ? 'transparent' : C.bor}`,
-              color: isReady ? '#000' : C.mut,
-              fontSize: 18, fontWeight: 900, fontFamily: FF,
-              letterSpacing: 1, cursor: isReady ? 'pointer' : 'default', textTransform: 'uppercase',
-              opacity: isSubmitting ? 0.6 : 1,
-            }}>
-            {isSubmitting ? 'Submitting…'
-              : isReady ? `✓  ${hasExistingSelections ? 'UPDATE PICKS' : 'SUBMIT PICKS'}`
-              : ptsLeft > 0 ? `DISTRIBUTE ${ptsLeft} MORE PTS`
-              : 'SELECT MORE GAMES'}
-          </button>
-        </div>
-        <div style={{ display: 'flex', padding: '8px 0 28px' }}>
-          {TABS.map((t) => (
-            <div key={t.label} onClick={() => navigate(t.path)}
-              style={{ flex: 1, display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 2, cursor: 'pointer', paddingTop: 4, position: 'relative' }}>
-              {t.active && <div style={{ position: 'absolute', top: 0, left: '50%', transform: 'translateX(-50%)', width: 28, height: 2.5, background: C.amb, borderRadius: 99 }} />}
-              {t.ico(t.active ? C.amb : C.mut)}
-              <span style={{ fontSize: 10, fontWeight: 700, letterSpacing: 0.5, color: t.active ? C.amb : C.mut, textTransform: 'uppercase' }}>{t.label}</span>
-            </div>
-          ))}
-        </div>
+      {/* Submit button — sits above the fixed LeagueTabBar */}
+      <div style={{ background: C.card, borderTop: `1px solid ${C.bor}`, padding: '10px 14px', paddingBottom: 78 }}>
+        <button onClick={handleSubmit} disabled={isSubmitting}
+          style={{
+            width: '100%', padding: '14px', borderRadius: 12,
+            background: isReady ? C.amb : '#162035',
+            border: `1px solid ${isReady ? 'transparent' : C.bor}`,
+            color: isReady ? '#000' : C.mut,
+            fontSize: 17, fontWeight: 900, fontFamily: FF,
+            letterSpacing: 1, cursor: isReady ? 'pointer' : 'default', textTransform: 'uppercase',
+            opacity: isSubmitting ? 0.6 : 1,
+          }}>
+          {isSubmitting ? 'Submitting…'
+            : isReady ? `✓  ${hasExistingSelections ? 'UPDATE PICKS' : 'SUBMIT PICKS'}`
+            : ptsLeft > 0 ? `DISTRIBUTE ${ptsLeft} MORE PTS`
+            : 'SELECT MORE GAMES'}
+        </button>
       </div>
+
+      <LeagueTabBar leagueId={leagueId} />
     </div>
   );
 };


### PR DESCRIPTION
- App.tsx: wrap all pages in a centered 720px max-width container so the mobile-first design sits as a clean centered column on desktop
- Navbar: inner content respects the 720px max-width
- LeagueTabBar: inner tab row respects 720px max-width so tabs stay centered on wide screens (matching the page content)
- Picksheet: replace custom hardcoded bottom nav with LeagueTabBar so it is consistent with all other in-league pages (including Commish tab)
- Picksheet game cards: reduce vertical height ~25% by tightening padding, shrinking abbr font (26→22px), removing the 'Open spread' line, and compacting the points stepper (h40→h34)
- Submit button sits above the fixed LeagueTabBar via paddingBottom: 78

https://claude.ai/code/session_018e7oNPu4nzjRQ8KEvdR8ng