### PR TITLE
Picksheet: make spread the visual focal point of each game card

### DIFF
--- a/client/src/pages/Picksheet.tsx
+++ b/client/src/pages/Picksheet.tsx
@@ -222,20 +222,20 @@ const Picksheet = () => {
                     <div key={team.id}
                       onClick={() => handleSelectTeam(game.id, team.id)}
                       style={{
-                        flex: 1, padding: '7px 10px', borderRadius: 8,
+                        flex: 1, padding: '10px 12px', borderRadius: 8,
                         cursor: locked ? 'default' : 'pointer',
                         background: on ? `${C.amb}1a` : C.d2,
                         border: `2px solid ${on ? C.amb : 'transparent'}`,
                         display: 'flex', alignItems: 'center', justifyContent: 'space-between',
                         userSelect: 'none', gap: 6, minWidth: 0,
                       }}>
-                      <div style={{ display: 'flex', alignItems: 'baseline', gap: 7, minWidth: 0 }}>
-                        <span style={{ fontSize: 22, fontWeight: 900, color: on ? C.amb : C.txt, lineHeight: 1, letterSpacing: -0.5 }}>{team.abbr}</span>
-                        <span style={{ fontSize: 13, fontWeight: 700, color: on ? C.amb : C.mut }}>{fmt(team.spread)}</span>
+                      <div style={{ display: 'flex', flexDirection: 'column', gap: 2, minWidth: 0 }}>
+                        <span style={{ fontSize: 13, fontWeight: 700, color: on ? C.amb : C.mut, letterSpacing: 1.2, textTransform: 'uppercase', lineHeight: 1 }}>{team.abbr}</span>
+                        <span style={{ fontSize: 26, fontWeight: 900, color: on ? C.amb : C.txt, lineHeight: 1, letterSpacing: -0.5 }}>{fmt(team.spread)}</span>
                       </div>
                       {on && (
-                        <div style={{ flexShrink: 0, width: 18, height: 18, borderRadius: 99, background: C.amb, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-                          <svg width="9" height="7" viewBox="0 0 11 9" fill="none"><path d="M1 4.5l3 3L10 1" stroke="#000" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"/></svg>
+                        <div style={{ flexShrink: 0, width: 20, height: 20, borderRadius: 99, background: C.amb, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                          <svg width="10" height="8" viewBox="0 0 11 9" fill="none"><path d="M1 4.5l3 3L10 1" stroke="#000" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"/></svg>
                         </div>
                       )}
                     </div>


### PR DESCRIPTION
Flip hierarchy in team buttons — spread number grows from 13px to 26px and becomes the dominant element; team abbr becomes a small 13px label above it. Increased button padding slightly to give the larger number room.

https://claude.ai/code/session_018e7oNPu4nzjRQ8KEvdR8ng