### PR TITLE
Fix 5 backend bugs: pick-em spread, streak ordering, redundant job, o…

### DIFF
--- a/backend/tasks/evaluateGameStart.js
+++ b/backend/tasks/evaluateGameStart.js
@@ -10,7 +10,7 @@ export async function checkAndUpdateGameStatus() {
     `);
 
     if (!games || games.length === 0) {
-      throw new Error('No games found in the database.');
+      return;
     }
 
     for (const game of games) {

--- a/backend/tasks/evaluateUserScores.js
+++ b/backend/tasks/evaluateUserScores.js
@@ -1,23 +1,29 @@
 import pool from '../config/db.js';
+import { calculateNFLWeekAndDay } from './nflWeekCalculator.js';
 
 export async function evaluateUserScores() {
   try {
+    const { week: currentWeek } = calculateNFLWeekAndDay(new Date());
+    // Process only the current and previous week — earlier weeks are already finalized in users_have_scores
+    const minWeek = Math.max(1, currentWeek - 1);
+
     // Fetch completed games from the database that also have spread_winner calculated
     const [games] = await pool.query(`
       SELECT id, spread_winner, home_curr_spread, home_team_id, away_team_id, week
       FROM games
-      WHERE game_completed = 1 AND spread_winner IS NOT NULL
-    `);
-    
-    console.log(`Found ${games.length} completed games with spread_winner calculated`);
+      WHERE game_completed = 1 AND spread_winner IS NOT NULL AND week >= ?
+      ORDER BY week ASC
+    `, [minWeek]);
+
+    console.log(`Found ${games.length} completed games with spread_winner calculated (week >= ${minWeek})`);
 
     // Fetch user selections with game details
     const [userSelections] = await pool.query(`
       SELECT usg.id AS selection_id, usg.user_id, usg.league_id, usg.game_id, usg.points, usg.team_id, g.week
       FROM users_select_games usg
       JOIN games g ON usg.game_id = g.id
-      WHERE g.game_completed = 1
-    `);
+      WHERE g.game_completed = 1 AND g.week >= ?
+    `, [minWeek]);
 
     const userScores = {};
 
@@ -82,7 +88,8 @@ export async function evaluateUserScores() {
       }
     }
 
-    for (const scoreKey of Object.keys(userScores)) {
+    const sortedScoreKeys = Object.keys(userScores).sort((a, b) => userScores[a].week - userScores[b].week);
+    for (const scoreKey of sortedScoreKeys) {
       const userScore = userScores[scoreKey];
       const leagueId = userScore.league_id;
 

--- a/backend/tasks/scheduler.js
+++ b/backend/tasks/scheduler.js
@@ -28,17 +28,6 @@ const triggerRoutes = async (routes) => {
   }
 };
 
-// One time Tuesday update.
-cron.schedule(
-  '51 * * * *',
-  () => {
-    triggerRoutes([evaluateGameStart, evaluateSpreads, evaluateUserScores]);
-  },
-  { timezone: TIMEZONE }
-);
-
-// REAL SCHEDULE IS HERE
-
 // Odds Update Schedule:
 // Tue-Mon at 8am EST (which is 1pm UTC)
 cron.schedule(

--- a/backend/tasks/updateOdds.js
+++ b/backend/tasks/updateOdds.js
@@ -48,7 +48,7 @@ export async function fetchAndSaveOdds() {
       );
       
       // Determine if we should update open spreads (Tuesday or if they don't exist)
-      const shouldUpdateOpenSpreads = isTuesday || (!existingSpreads[0]?.home_open_spread && !existingSpreads[0]?.away_open_spread);
+      const shouldUpdateOpenSpreads = isTuesday || (existingSpreads[0]?.home_open_spread == null && existingSpreads[0]?.away_open_spread == null);
 
       // Parse the API response into variables
       for (const bookmaker of game.bookmakers) {


### PR DESCRIPTION
…ff-season noise, full-history rescan

- updateOdds: use == null instead of falsy check so spread=0 (pick-em) doesn't overwrite open spread daily
- evaluateUserScores: sort scoreKeys by week before Phase 2 so streak reads correct prior-week DB data
- evaluateUserScores: filter games/selections to week >= currentWeek-1 instead of all-time; add ORDER BY week ASC
- evaluateUserScores: import calculateNFLWeekAndDay for the week filter
- scheduler: remove redundant :51 hourly job (identical to the :05 job + every-5-min evaluateGameStart)
- evaluateGameStart: return early on empty games table instead of throwing (eliminates off-season error spam)

https://claude.ai/code/session_018e7oNPu4nzjRQ8KEvdR8ng