### PR TITLE
Redirect single-league users to their league on login; add My Leagues…

### DIFF
--- a/client/src/pages/League.tsx
+++ b/client/src/pages/League.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, Link } from 'react-router-dom';
 import axios from 'axios';
 import LeagueTabBar from '../components/LeagueTabBar.tsx';
 import apiUrl from '../services/serverConfig.ts';
@@ -48,6 +48,14 @@ const League = () => {
 
       {!isLoading && leagueInfo && (
         <div style={{ padding: '16px 20px 88px' }}>
+          <Link to="/" style={{
+            display: 'inline-flex', alignItems: 'center', gap: 6,
+            marginBottom: 14, textDecoration: 'none',
+            fontFamily: FFb, fontSize: 13, fontWeight: 700,
+            color: C.mut, textTransform: 'uppercase', letterSpacing: 0.8,
+          }}>
+            ‹ My Leagues
+          </Link>
           <div style={{ background: C.card, borderRadius: 12, padding: '0 16px', border: `1px solid ${C.bor}` }}>
             <InfoRow label="Sport" value={leagueInfo.sport?.toUpperCase()} />
             <InfoRow label="Season" value={leagueInfo.year} />

--- a/client/src/pages/Login.tsx
+++ b/client/src/pages/Login.tsx
@@ -2,8 +2,11 @@ import React, { useState, useContext } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { AuthContext } from '../context/AuthContext.tsx';
+import fetchUserLeagues from '../services/fetchUserLeagues.ts';
 import apiUrl from '../services/serverConfig.ts';
 import logo from '../assets/STL_Logo.webp';
+
+const CURRENT_NFL_YEAR = parseInt(import.meta.env.VITE_NFL_YEAR || '2025', 10);
 
 const C = {
   bg: '#0c1628', card: '#152540', d2: '#1a2d4a',
@@ -37,7 +40,13 @@ const Login = () => {
     try {
       const res = await axios.post(`${apiUrl}/auth/login`, formData);
       login(res.data);
-      navigate('/');
+      const leagues = await fetchUserLeagues(res.data.userId);
+      const active = leagues.filter((l: any) => l.year === CURRENT_NFL_YEAR);
+      if (active.length === 1) {
+        navigate(`/league/${active[0].league_id}/picksheet`);
+      } else {
+        navigate('/');
+      }
     } catch (err: any) {
       setError(err.response?.data?.msg || 'Login failed');
     }


### PR DESCRIPTION
… back button

- Login: after auth, fetch user's leagues for the current NFL year; if exactly one, go directly to /league/:id/picksheet instead of home
- League page: add '‹ My Leagues' link back to / so users with multiple leagues (or who navigated directly) can return to the home screen

https://claude.ai/code/session_018e7oNPu4nzjRQ8KEvdR8ng