### PR TITLE
Reduce API quota usage: tighten odds/scores schedule, add off-season …

### DIFF
--- a/backend/tasks/scheduler.js
+++ b/backend/tasks/scheduler.js
@@ -1,26 +1,22 @@
 import cron from 'node-cron';
 import axios from 'axios';
+import { calculateNFLWeekAndDay } from './nflWeekCalculator.js';
 
 const BASE_URL = process.env.BACKEND_URL || 'localhost';
 const PORT = process.env.BACKEND_PORT || '3000';
 const TIMEZONE = process.env.TASK_TIMEZONE || 'America/New_York';
 
-// URL of the route you want to trigger
-const getOdds = `http://${BASE_URL}:${PORT}/getodds`;
-const getScores = `http://${BASE_URL}:${PORT}/getscores`;
 const updateOdds = `http://${BASE_URL}:${PORT}/updateodds`;
 const updateScores = `http://${BASE_URL}:${PORT}/updatescores`;
 const evaluateSpreads = `http://${BASE_URL}:${PORT}/evaluatespreads`;
 const evaluateUserScores = `http://${BASE_URL}:${PORT}/evaluateuserscores`;
 const evaluateGameStart = `http://${BASE_URL}:${PORT}/evaluategamestart`;
 
-// Function to trigger the route
 const triggerRoutes = async (routes) => {
   for (const url of routes) {
     console.log(`Triggering ${url}...`);
     try {
       await axios.get(url, { timeout: 15000 });
-      // console.log(`Route ${url} triggered successfully.`);
     } catch (error) {
       console.error(`Error triggering ${url}:`, error.message);
       continue;
@@ -28,83 +24,82 @@ const triggerRoutes = async (routes) => {
   }
 };
 
-// Odds Update Schedule:
-// Tue-Mon at 8am EST (which is 1pm UTC)
+const inSeason = () => calculateNFLWeekAndDay(new Date()).week > 0;
+
+// Odds Update Schedule: Tue, Thu, Sat, Sun at 8am ET
+// Tue: open spreads reset (isTuesday flag), Thu: TNF prep, Sat/Sun: weekend slate
 cron.schedule(
-  '0 8 * * *',
+  '0 8 * * 0,2,4,6',
   () => {
+    if (!inSeason()) return;
     triggerRoutes([updateOdds]);
   },
   { timezone: TIMEZONE }
 );
 
 // Scores Update Schedule:
-// Thu at Midnight EDT (which is 4am UTC Fri)
+
+// Fri 2am ET — TNF wrap-up
 cron.schedule(
-  '0 1,3 * * 5',
+  '0 2 * * 5',
   () => {
+    if (!inSeason()) return;
     triggerRoutes([updateScores]);
   },
   { timezone: TIMEZONE }
 );
 
-// Sun at 5pm EDT (late afternoon slate)
+// Sun 5pm ET — early afternoon slate wrap-up
 cron.schedule(
   '0 17 * * 0',
   () => {
+    if (!inSeason()) return;
     triggerRoutes([updateScores]);
   },
   { timezone: TIMEZONE }
 );
 
-// Sun at 8pm EDT (post afternoon slate / pre-SNF)
+// Sun 8pm ET — late afternoon slate wrap-up / pre-SNF
 cron.schedule(
   '0 20 * * 0',
   () => {
+    if (!inSeason()) return;
     triggerRoutes([updateScores]);
   },
   { timezone: TIMEZONE }
 );
 
-// Mon at 1am, 3am EDT for SNF wrap-up
+// Mon 2am ET — SNF wrap-up
 cron.schedule(
-  '0 1,3 * * 1',
+  '0 2 * * 1',
   () => {
+    if (!inSeason()) return;
     triggerRoutes([updateScores]);
   },
   { timezone: TIMEZONE }
 );
 
-// Tue at 1am, 3am EDT for MNF wrap-up
+// Tue 2am ET — MNF wrap-up
 cron.schedule(
-  '0 1,3 * * 2',
+  '0 2 * * 2',
   () => {
+    if (!inSeason()) return;
     triggerRoutes([updateScores]);
   },
   { timezone: TIMEZONE }
 );
 
-// Daily 9am ET safety net to catch any stragglers
-cron.schedule(
-  '0 9 * * *',
-  () => {
-    triggerRoutes([updateScores]);
-  },
-  { timezone: TIMEZONE }
-);
-
-// Results Update Schedule: Hourly from Tue-Mon in EST (which is every hour in UTC)
+// Results evaluation: every hour at :05
 cron.schedule(
   '5 * * * *',
   async () => {
-    // Run evaluateSpreads first, then evaluateUserScores
     await triggerRoutes([evaluateSpreads]);
     await triggerRoutes([evaluateUserScores]);
   },
   { timezone: TIMEZONE }
 );
 
-// GameStart Update Schedule: Every 5 minutes.
+// Game start check: every 5 minutes
 cron.schedule(
   '*/5 * * * *',
   () => {
@@ -115,32 +110,21 @@ cron.schedule(
 
 console.log('Scheduler is running...');
 
-/* Odds Update Schedule:
-Tue: 8am
-Wed: 8am
-Thu: 8am
-Fri: 8am
-Sat: 8am
-Sun: 8am
-Mon: 8am
+/* Odds Update Schedule (in-season only, America/New_York):
+Tue: 8am (open spreads reset)
+Thu: 8am (TNF prep)
+Sat: 8am (weekend slate)
+Sun: 8am (final line check before 1pm kickoffs)
 */
 
-/* Scores Update Schedule (America/New_York):
-Tue: 1am, 3am (wrap MNF) + 9am safety net
-Wed: 9am safety net
-Thu: 9am safety net
-Fri: 1am, 3am (wrap TNF) + 9am safety net
-Sat: 9am safety net
-Sun: 5pm, 8pm, 9am safety net
-Mon: 1am, 3am (wrap SNF) + 9am safety net
+/* Scores Update Schedule (in-season only, America/New_York):
+Fri: 2am (TNF wrap-up)
+Sun: 5pm, 8pm (early + late slate)
+Mon: 2am (SNF wrap-up)
+Tue: 2am (MNF wrap-up)
 */
 
-/* Results Update Schedule:
-Tue: Hourly
-Wed: Hourly
-Thu: Hourly
-Fri: Hourly
-Sat: Hourly
-Sun: Hourly
-Mon: Hourly
+/* Results/GameStart Schedule (year-round, DB only — no API cost):
+evaluateSpreads + evaluateUserScores: hourly at :05
+evaluateGameStart: every 5 minutes
 */


### PR DESCRIPTION
…gate

Odds (was daily, now Tue/Thu/Sat/Sun at 8am ET):
- Tue: critical — isTuesday flag resets open spreads
- Thu: TNF prep
- Sat: full weekend slate is posted by Saturday morning
- Sun: final line check before 1pm kickoffs
- Saves ~17 calls/month vs daily (31 → ~13-17)

Scores (removed daily 9am safety net, consolidated 1am+3am → 2am):
- Fri 2am: TNF wrap-up (was 1am+3am)
- Sun 5pm+8pm: unchanged, needed for early/late slate boundary
- Mon 2am: SNF wrap-up (was 1am+3am)
- Tue 2am: MNF wrap-up (was 1am+3am)
- Removes daily safety net (was 31×/month × 2 credits = 62 wasted credits)

Off-season gate (inSeason() check on all API jobs):
- updateOdds and updateScores skip entirely when week === 0
- evaluateSpreads/evaluateUserScores/evaluateGameStart are DB-only so still run year-round at no API cost

Peak in-season month estimate: ~278 credits (well under 500 limit)
Off-season: 0 credits

https://claude.ai/code/session_018e7oNPu4nzjRQ8KEvdR8ng