### PR TITLE
Show 'N pts over' on Picksheet submit bar when points exceed the pool

### DIFF
--- a/client/src/pages/Picksheet.tsx
+++ b/client/src/pages/Picksheet.tsx
@@ -182,7 +182,8 @@ const Picksheet = () => {
   // Status text for the submit bar button
   const submitLabel = isSubmitting ? 'Saving…'
     : isReady ? (hasExistingSelections ? 'Update ✓' : 'Submit ✓')
-    : ptsLeft > 0 ? `${ptsLeft} pts left`
+    : ptsLeft > 0 ? `${ptsLeft} ${ptsLeft === 1 ? 'pt' : 'pts'} left`
+    : ptsLeft < 0 ? `${-ptsLeft} ${-ptsLeft === 1 ? 'pt' : 'pts'} over`
     : 'Pick more';
 
   const weekBtn = (dir: number, disabled: boolean) => (


### PR DESCRIPTION
The status label fell through to 'Pick more' whenever ptsLeft <= 0, so over-allocating points (e.g. 9/8) showed a pick-count instruction even when the pick count was fine. 'Pick more' now only appears when points are exactly allocated but picks are below the league minimum. Also singularizes 'pt' for 1-point deltas.

https://claude.ai/code/session_018e7oNPu4nzjRQ8KEvdR8ng